### PR TITLE
Fix Service Principal creation script

### DIFF
--- a/eval/autodeploy/README.md
+++ b/eval/autodeploy/README.md
@@ -212,11 +212,9 @@ New-AzRoleAssignment -ObjectId $sp.Id `
 
 # Retrieve the password for the Service Principal
 
-$secret = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR(
-    [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-)
+$secret = $sp.PasswordCredentials[0].SecretText
 
-Write-Host "Application ID: $($sp.ApplicationId)"
+Write-Host "Application ID: $($sp.AppId)"
 Write-Host "App Secret: $secret"
 ```
 


### PR DESCRIPTION
`$sp` that returned value from **New-AzADServicePrincipal** cmdlet haven't **ApplicationId** property and **Secret** property. Those properties do not exist in the latest (5.4.0) Az.Resources module.