### PR TITLE
Fix untrusted search path in LinuxImageValidate.py (CWE-426)

### DIFF
--- a/scripts/ImageSignValidation/LinuxImageValidate.py
+++ b/scripts/ImageSignValidation/LinuxImageValidate.py
@@ -5,6 +5,16 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
+# Resolve trusted paths relative to this script's own directory rather than the
+# caller's current working directory. This prevents an attacker who controls the
+# launch directory from planting a malicious `notation` binary (or cert/policy
+# files) that would run as the script user and fake successful signature
+# verification. Mirrors the $PSScriptRoot pattern used by WindowsImageValidate.ps1.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+NOTATION = os.path.join(SCRIPT_DIR, "notation")
+CA_CERT = os.path.join(SCRIPT_DIR, "ca.crt")
+TSA_CERT = os.path.join(SCRIPT_DIR, "tsa.crt")
+
 def run_command(command):
     try:
         subprocess.run(command, check=True, capture_output=True, text=True)
@@ -30,22 +40,23 @@ def verify_image(image):
     }
 
     trust_json = json.dumps(trust_data)
-    with open("trust.json", "w") as f:
+    trust_path = os.path.join(SCRIPT_DIR, "trust.json")
+    with open(trust_path, "w") as f:
         f.write(trust_json)
 
-    run_command(["./notation", "policy", "import", "trust.json", "--force"])
-    run_command(["./notation", "policy", "show"])
-    result = run_command(["./notation", "verify", image, "--verbose"])
+    run_command([NOTATION, "policy", "import", trust_path, "--force"])
+    run_command([NOTATION, "policy", "show"])
+    result = run_command([NOTATION, "verify", image, "--verbose"])
     if not result:
-        run_command(["./notation", "inspect", image, "--verbose"])
-    os.remove("trust.json")
+        run_command([NOTATION, "inspect", image, "--verbose"])
+    os.remove(trust_path)
     return result
 
-def ensure_certs(cert_type, store, cert_name):
-    result = subprocess.run(["./notation", "cert", "ls", "--type", cert_type, "--store", store, cert_name], capture_output=True, text=True, check=True)
+def ensure_certs(cert_type, store, cert_name, cert_path):
+    result = subprocess.run([NOTATION, "cert", "ls", "--type", cert_type, "--store", store, cert_name], capture_output=True, text=True, check=True)
     if not result.stdout.strip():
-        run_command(["./notation", "cert", "add", "--type", cert_type, "--store", store, cert_name])
-        run_command(["./notation", "cert", "ls", "--type", cert_type])
+        run_command([NOTATION, "cert", "add", "--type", cert_type, "--store", store, cert_path])
+        run_command([NOTATION, "cert", "ls", "--type", cert_type])
 
 def get_crictl_images_with_none_tag():
     # Run the crictl command and capture the output
@@ -63,8 +74,8 @@ def get_crictl_images_with_none_tag():
 
 def ensure_trust():
     tool_name = "notation"
-    ensure_certs("ca", "supplychain", "ca.crt")
-    ensure_certs("tsa", "esrp", "tsa.crt")
+    ensure_certs("ca", "supplychain", "ca.crt", CA_CERT)
+    ensure_certs("tsa", "esrp", "tsa.crt", TSA_CERT)
 
     images = get_crictl_images_with_none_tag()
     failed_images = []


### PR DESCRIPTION
## Summary

Fixes a **CWE-426 (Untrusted Search Path)** defect in `scripts/ImageSignValidation/LinuxImageValidate.py`.

The script executed `./notation` and read/wrote `trust.json`, `ca.crt`, and `tsa.crt` **relative to the caller's current working directory**. Because the argv[0] `./notation` contains a slash, `subprocess` runs the file named `notation` in the launch directory (it does not consult `PATH`). A user who controls the launch directory could plant a malicious `notation` binary that:

1. Runs arbitrary code as the script user, and
2. Returns exit code 0 to make image-signature verification appear successful (the wrapper only checks exit status).

The cert/policy files were similarly cwd-relative, so the whole validation workflow depended on where the caller launched the script rather than on a trusted, script-owned directory.

## Fix

Resolve the `notation` executable and all trust/policy/cert files relative to the **script's own directory** (`os.path.dirname(os.path.abspath(__file__))`), mirroring the `$PSScriptRoot` pattern already used by the Windows companion `WindowsImageValidate.ps1`:

- `NOTATION = os.path.join(SCRIPT_DIR, "notation")` used for every invocation (replaces `./notation`).
- `trust.json` written/imported/removed from `SCRIPT_DIR`.
- `ensure_certs` now takes an explicit `cert_path`; `cert add` uses the absolute script-dir cert path while `cert ls` keeps the logical store name (`ca.crt`/`tsa.crt`) — matching the Windows `Install-Certs` behavior.

Because `NOTATION` is an absolute path, `subprocess` still does not fall back to `PATH`, so behavior is equivalent to the original (binary sits next to the script) but is no longer influenced by the caller's cwd.

## Testing

- `python3 -m py_compile scripts/ImageSignValidation/LinuxImageValidate.py` passes.
- Code review confirmed the executable and all cert/policy inputs are now script-dir anchored with no remaining cwd-relative trusted inputs.

Note: the results *output* file (`imagevalidation_results_linux.json`) is intentionally left cwd-relative; it is a computed output, not a trust/exec surface.